### PR TITLE
Replace deprecated react/jsx-quotes with jsx-quotes

### DIFF
--- a/config/base.json
+++ b/config/base.json
@@ -12,6 +12,7 @@
     "default-case": 2,
     "dot-notation": [2, {"allowPattern": "^[a-z]+(_[a-z]+)+$"}],
     "indent": [2, 2],
+    "jsx-quotes": 2,
     "no-cond-assign": 2,
     "no-console": 2,
     "no-constant-condition": 2,

--- a/config/react.json
+++ b/config/react.json
@@ -7,7 +7,6 @@
   },
   "rules": {
     "react/jsx-boolean-value": 2,
-    "react/jsx-quotes": 2,
     "react/jsx-no-undef": 2,
     "react/jsx-sort-props": 2,
     "react/jsx-sort-prop-types": 2,


### PR DESCRIPTION
react/jsx-quotes [has been deprecated](https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-quotes.md) in favor of [jsx-quotes](http://eslint.org/docs/rules/jsx-quotes).