### PR TITLE
One level of indentation for switch case

### DIFF
--- a/config/base.json
+++ b/config/base.json
@@ -11,7 +11,7 @@
     "comma-style": 2,
     "default-case": 2,
     "dot-notation": [2, {"allowPattern": "^[a-z]+(_[a-z]+)+$"}],
-    "indent": [2, 2],
+    "indent": [2, 2, {"SwitchCase": 1}],
     "jsx-quotes": 2,
     "no-cond-assign": 2,
     "no-console": 2,


### PR DESCRIPTION
Most of the code we have currently indents switch cases by one level.
