### PR TITLE
Updated base and React config

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,6 +6,8 @@ module.exports = {
   },
   rules: {
     'array-bracket-spacing': 2,
+    'array-callback-return': 2,
+    'arrow-parens': [2, 'as-needed'],
     'block-scoped-var': 2,
     'brace-style': 2,
     'comma-dangle': [2, 'never'],

--- a/package.json
+++ b/package.json
@@ -12,8 +12,8 @@
     "url": "git://github.com/planetlabs/eslint-config-planet.git"
   },
   "devDependencies": {
-    "eslint": "2.11.1",
-    "eslint-plugin-react": "^5.1.1"
+    "eslint": "3.15.0",
+    "eslint-plugin-react": "^6.9.0"
   },
   "peerDependencies": {
     "eslint": ">= 2.0"

--- a/react.js
+++ b/react.js
@@ -19,14 +19,18 @@ module.exports = {
     'react/jsx-sort-props': 2,
     'react/jsx-uses-react': 2,
     'react/jsx-uses-vars': 2,
+    'react/jsx-wrap-multilines': 2,
+    'react/no-array-index-key': 2,
+    'react/no-children-prop': 2,
     'react/no-did-mount-set-state': 2,
     'react/no-did-update-set-state': 2,
+    'react/no-direct-mutation-state': 2,
     'react/no-multi-comp': 2,
+    'react/no-unescaped-entities': 2,
     'react/no-unknown-property': 2,
+    'react/no-unused-prop-types': 2,
     'react/prop-types': 2,
     'react/react-in-jsx-scope': 2,
-    'react/self-closing-comp': 2,
-    'react/sort-prop-types': 2,
-    'react/wrap-multilines': 2
+    'react/sort-prop-types': 2
   }
 };


### PR DESCRIPTION
This suggests adding a few rules at the error level (so will require a major version bump).

List of changes with motivation

 * [`array-callback-return`](http://eslint.org/docs/rules/array-callback-return) - e.g. keeps people from using `map` inappropriately
 * [`arrow-parens`](http://eslint.org/docs/rules/arrow-parens) - with the "as-needed" option, this conforms to our current use (e.g. `foo.map(item => item.id)` and `foo.map((item, index) => index)` only has parens around args where needed)
 * [`react/jsx-wrap-multilines`](https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-wrap-multilines.md) - enforces consistency with our current style
 * [`react/no-array-index-key`](https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/no-array-index-key.md) - we've had rendering bugs related to using unstable array index, we can start by configuring this as a warning and work toward error level config
 * [`react/no-children-prop`](https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/no-children-prop.md) - enforces consistency with current style (& common sense)
 * [`react/no-direct-mutation-state`](https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/no-direct-mutation-state.md) - enforces consistency with current style (& common sense)
 * [`react/no-unescaped-entities`](https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/no-unescaped-entities.md) - avoids misplaced closing tags
 * [`react/no-unused-prop-types`](https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/no-unused-prop-types.md) - avoids cruft after refactoring

