### PR TITLE
Peg prettier to avoid breaking changes

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   },
   "dependencies": {
     "eslint-config-prettier": "1.5.0",
-    "eslint-plugin-prettier": "^2.0.1",
-    "prettier": "^1.1.0"
+    "eslint-plugin-prettier": "2.0.1",
+    "prettier": "1.1.0"
   }
 }


### PR DESCRIPTION
There are changes coming in minor and patch releases for Prettier that are "breaking" from our perspective (e.g. prettier/prettier#1344).  We can bump major versions here when we want to upgrade Prettier.

I'll release this as a patch so builds are fixed where we are depending on `eslint-config-planet@13`.