### PR TITLE
Remove the react/no-multi-comp rule

### DIFF
--- a/react.js
+++ b/react.js
@@ -24,7 +24,6 @@ module.exports = {
     'react/no-did-mount-set-state': "error",
     'react/no-did-update-set-state': "error",
     'react/no-direct-mutation-state': "error",
-    'react/no-multi-comp': "error",
     'react/no-unescaped-entities': "error",
     'react/no-unknown-property': "error",
     'react/no-unused-prop-types': "error",


### PR DESCRIPTION
We've found that this rule produces false positives (and have disabled it in a number of places).  I don't think we risk anything by no longer enforcing it.