### PR TITLE
Enforce `prefer-const`

### DIFF
--- a/index.js
+++ b/index.js
@@ -55,6 +55,7 @@ module.exports = {
     'no-use-before-define': ["error", 'nofunc'],
     'strict': "off",
     'use-isnan': "error",
-    'valid-typeof': "error"
+    'valid-typeof': "error",
+    'prefer-const': "error"
   }
 };


### PR DESCRIPTION
From ESLint rule page:

> The `--fix` option on the command line can automatically fix some of the problems reported by this rule.
> If a variable is never reassigned, using the `const` declaration is better.
> `const` declaration tells readers, “this variable is never reassigned,” reducing cognitive load and improving maintainability.

Link to rule: https://eslint.org/docs/rules/prefer-const