### PR TITLE
Tweak `no-unused-vars` rule

### DIFF
--- a/index.js
+++ b/index.js
@@ -52,11 +52,7 @@ module.exports = {
     'no-unexpected-multiline': 'error',
     'no-unreachable': 'error',
     'no-unsafe-finally': 'error',
-    'no-unused-vars': ['error', {
-      vars: 'all',
-      args: 'after-used',
-      ignoreRestSiblings: true
-    }],
+    'no-unused-vars': ['error', {ignoreRestSiblings: true}],
     'no-use-before-define': ['error', 'nofunc'],
     strict: 'off',
     'use-isnan': 'error',

--- a/index.js
+++ b/index.js
@@ -52,7 +52,11 @@ module.exports = {
     'no-unexpected-multiline': 'error',
     'no-unreachable': 'error',
     'no-unsafe-finally': 'error',
-    'no-unused-vars': ['error', {vars: 'all', args: 'none'}],
+    'no-unused-vars': ['error', {
+      vars: 'all',
+      args: 'after-used',
+      ignoreRestSiblings: true
+    }],
     'no-use-before-define': ['error', 'nofunc'],
     strict: 'off',
     'use-isnan': 'error',


### PR DESCRIPTION
- Raise errors when arguments are unused
- Allow to use rest operator to discard unwanted siblings