### PR TITLE
chore: upgrade eslint and prettier packages

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -423,20 +423,27 @@
       }
     },
     "eslint-config-prettier": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-2.4.0.tgz",
-      "integrity": "sha1-+3zynAqyumGvUWT7GTD5vvO+KHI=",
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-2.6.0.tgz",
+      "integrity": "sha1-8h2w67Q4rWePuYlGCXxLsZi+/Mw=",
       "requires": {
         "get-stdin": "5.0.1"
       }
     },
     "eslint-plugin-prettier": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-2.2.0.tgz",
-      "integrity": "sha512-LmIOP99A+BMeMYZoDeU196cV7FNIHJEjjWLARdz6JSTYmGK+HTEAVbJukPr/ZVOKPs5Hf7b10aXwSbty6Gqqsw==",
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-2.3.1.tgz",
+      "integrity": "sha512-AV8shBlGN9tRZffj5v/f4uiQWlP3qiQ+lh+BhTqRLuKSyczx+HRWVkVZaf7dOmguxghAH1wftnou/JUEEChhGg==",
       "requires": {
         "fast-diff": "1.1.1",
-        "jest-docblock": "20.0.3"
+        "jest-docblock": "21.2.0"
+      },
+      "dependencies": {
+        "jest-docblock": {
+          "version": "21.2.0",
+          "resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-21.2.0.tgz",
+          "integrity": "sha512-5IZ7sY9dBAYSV+YjQ0Ovb540Ku7AO9Z5o2Cg789xj167iQuZ2cG+z0f3Uct6WeYLbU6aQiM2pCs7sZ+4dotydw=="
+        }
       }
     },
     "eslint-plugin-react": {
@@ -831,11 +838,6 @@
         "whatwg-fetch": "2.0.3"
       }
     },
-    "jest-docblock": {
-      "version": "20.0.3",
-      "resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-20.0.3.tgz",
-      "integrity": "sha1-F76phDQswz2DxQ++FUXqDvqkRxI="
-    },
     "js-tokens": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
@@ -1077,9 +1079,9 @@
       "dev": true
     },
     "prettier": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.6.1.tgz",
-      "integrity": "sha512-f85qBoQiqiFM/sCmJaN4Lagj9bqMcv38vCftqp4GfVessAqq3Ns6g+3gd8UXReStLLE/DGEdwiZXoFKxphKqwg=="
+      "version": "1.7.4",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.7.4.tgz",
+      "integrity": "sha1-XoYkrpNjyA+V7GRFhOzfVddPk/o="
     },
     "process-nextick-args": {
       "version": "1.0.7",

--- a/package.json
+++ b/package.json
@@ -22,9 +22,9 @@
     "eslint": ">= 4.0"
   },
   "dependencies": {
-    "eslint-config-prettier": "^2.4.0",
-    "eslint-plugin-prettier": "^2.2.0",
-    "prettier": "^1.6.1"
+    "eslint-config-prettier": "^2.6.0",
+    "eslint-plugin-prettier": "^2.3.1",
+    "prettier": "^1.7.4"
   },
   "eslintConfig": {
     "extends": "./index.js"


### PR DESCRIPTION
Upgrades, especially to resolve incompatibility with latest atom:

![image](https://user-images.githubusercontent.com/4950310/31197732-dc9f4014-a906-11e7-94ce-713a06fcfafc.png)

https://github.com/prettier/prettier-atom/issues/268#issuecomment-329789268