### PR TITLE
feat: don't allow function param reassignment

### DIFF
--- a/index.js
+++ b/index.js
@@ -43,6 +43,7 @@ module.exports = {
     'no-negated-in-lhs': 'error',
     'no-obj-calls': 'error',
     'no-octal': 'error',
+    'no-param-reassign': ['error', {props: true}],
     'no-process-exit': 'off',
     'no-redeclare': 'error',
     'no-regex-spaces': 'error',


### PR DESCRIPTION
## Changes
- don't allow function parameter re-assignment, even nested ones: https://eslint.org/docs/rules/no-param-reassign

## Rationale
In almost all cases, you don't want to be mutating the object reference of the argument of a function. That prevents functions from being pure, and can have unexpected side effects. This linter rule catches most common accidental mutations.


## Notes

This can still be accidentally defeated, such as in the following example, so you still have to be careful with what you're doing, and think whether shallow object copies are what you want to do:

```javascript
function getObjectsWithArea(objects) {
  const newObjects = {...objects}; // this is a shallow copy!!
  for (const object in objects) {
    // Oops, we're actually reassigning a value referenced by the 'objects' arg.
    // Accidental side effect!!
    newObjects[object].area =
      newObjects[object].width * newObjects[object].height;
  }

  return newObjects;
}

const objects = {paper: {width: 10, height: 50}};
console.log('objects before: ', JSON.stringify(objects));
// logs: objects before:  {"paper":{"width":10,"height":50}}
getObjectsWithArea(objects);
console.log('objects after: ', JSON.stringify(objects));
// logs: objects after:  {"paper":{"width":10,"height":50,"area":500}}
// Oops, we didn't mean to mutate that!

```

If you want to be sure you're not mutating, this could be better written (with the tradeoff of temporary extra variable and anonymous function assignment, and worse readability) as:
```javascript
function getObjectsWithArea(objects) {
  // Wouldn't it be nice if we had a native Object.prototype.map?!?
  return Object.keys(objects).reduce((newObjects, key) => {
    return {
      ...newObjects,
      [key]: {
        ...objects[key],
        area: objects[key].width * objects[key].height,
      },
    };
  }, {});
}
```

## Exceptions
Notable exceptions, where you DO want to mutate are if you're in a very hot function that gets called a lot (eg. preCompose OL hook) and you don't want extra variable assignments. In those cases, doing `/*eslint no-param-reassign: "off"*/` or `// eslint-disable-line no-param-reassign` should be sufficient.