### PR TITLE
feat: ignore unused func args

### DIFF
--- a/index.js
+++ b/index.js
@@ -53,7 +53,7 @@ module.exports = {
     'no-unexpected-multiline': 'error',
     'no-unreachable': 'error',
     'no-unsafe-finally': 'error',
-    'no-unused-vars': ['error', {ignoreRestSiblings: true}],
+    'no-unused-vars': ['error', {ignoreRestSiblings: true, args: 'none'}],
     'no-use-before-define': ['error', 'nofunc'],
     strict: 'off',
     'use-isnan': 'error',


### PR DESCRIPTION
## Changes
- Ignore unused function args

## Rationale
It's really nice to see the function signature, even if you're not using all the arguments:

eg:
```javascript
class MyComponent extends Component {
  shouldComponentUpdate(nextProps, nextState) {
    // even if I'm not using nextProps or nextState, it's nice to see the signature for future refactoring or functionality additions
  }
}
```

eg:
```javascript
return new Promise((resolve, reject) => {
  resolve('foo');
  // again, nice to see reject in the arguments list, even if I'm not using it at the moment.
  // In fact, it might even remind me not to ignore the error case!
});

```