### PR TITLE
Shut down `react/display-name`

### DIFF
--- a/react.js
+++ b/react.js
@@ -14,6 +14,7 @@ module.exports = {
   rules: {
     'react-hooks/exhaustive-deps': 'warn',
     'react-hooks/rules-of-hooks': 'error',
+    'react/display-name': 'off',
     'react/jsx-boolean-value': 'error',
     'react/jsx-key': 'error',
     'react/jsx-no-duplicate-props': 'error',


### PR DESCRIPTION
On our experience, adding the `displayName` to all the components has been irrelevant for sake of testing, debugging and ease of development.

unearthing this old branch