### PR TITLE
Move import sorting to main ruleset

### DIFF
--- a/examples/es6/local-module.js
+++ b/examples/es6/local-module.js
@@ -1,0 +1,3 @@
+const foo = 'bar';
+
+export default foo;

--- a/examples/es6/main.js
+++ b/examples/es6/main.js
@@ -1,8 +1,8 @@
-const fs = require('fs');
-const path = require('path');
+import fs from 'fs';
+import path from 'path';
 
-function main(paths) {
-  return Promise.all(
+const main = paths =>
+  Promise.all(
     paths.map(name => {
       return new Promise((resolve, reject) => {
         fs.readFile(name, (err, data) => {
@@ -15,7 +15,6 @@ function main(paths) {
       });
     })
   );
-}
 
 exports.modifyProps = props => {
   props.foo = 'bar';

--- a/examples/es6/main.js
+++ b/examples/es6/main.js
@@ -1,6 +1,8 @@
 import fs from 'fs';
 import path from 'path';
 
+import foo from './local-module';
+
 const main = paths =>
   Promise.all(
     paths.map(name => {
@@ -17,7 +19,7 @@ const main = paths =>
   );
 
 exports.modifyProps = props => {
-  props.foo = 'bar';
+  props.foo = foo;
 };
 
 if (require.main === module) {

--- a/examples/es6/main.js
+++ b/examples/es6/main.js
@@ -1,7 +1,6 @@
+import foo from './local-module';
 import fs from 'fs';
 import path from 'path';
-
-import foo from './local-module';
 
 const main = paths =>
   Promise.all(

--- a/examples/react/component.js
+++ b/examples/react/component.js
@@ -2,7 +2,7 @@ import React, {useCallback, useState} from 'react';
 import ReactDOM from 'react-dom';
 import {string} from 'prop-types';
 
-function HelloMessage({name}) {
+const HelloMessage = ({name}) => {
   const [greeting, setGreeting] = useState('Hello');
 
   const onClick = useCallback(() => {
@@ -14,7 +14,7 @@ function HelloMessage({name}) {
       {greeting} {name}
     </div>
   );
-}
+};
 
 HelloMessage.propTypes = {
   name: string.isRequired,

--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 module.exports = {
   extends: ['prettier'],
-  plugins: ['prettier', 'import'],
+  plugins: ['import', 'prettier', 'sort-imports-es6-autofix'],
   env: {
     node: true,
     browser: true,
@@ -11,28 +11,29 @@ module.exports = {
     sourceType: 'module',
   },
   rules: {
-    'prettier/prettier': [
-      'error',
-      {
-        singleQuote: true,
-        bracketSpacing: false,
-        trailingComma: 'es5',
-        arrowParens: 'avoid',
-      },
-    ],
     'array-callback-return': 'error',
     'block-scoped-var': 'error',
     curly: 'error',
     'default-case': 'error',
     'dot-notation': ['error', {allowPattern: '^[a-z]+(_[a-z]+)+$'}],
     eqeqeq: 'error',
-    'import/no-unresolved': ['error', {commonjs: true}],
-    'import/named': 'error',
     'import/default': 'error',
+    'import/named': 'error',
+    'import/no-unresolved': ['error', {commonjs: true}],
+    'import/order': [
+      'error',
+      {
+        groups: [
+          ['builtin', 'external'],
+          ['internal', 'parent', 'sibling', 'index'],
+        ],
+        'newlines-between': 'always',
+      },
+    ],
     'no-case-declarations': 'error',
     'no-cond-assign': 'error',
-    'no-const-assign': 'error',
     'no-console': 'error',
+    'no-const-assign': 'error',
     'no-control-regex': 'error',
     'no-debugger': 'error',
     'no-delete-var': 'error',
@@ -65,9 +66,26 @@ module.exports = {
     'no-unused-vars': ['error', {ignoreRestSiblings: true}],
     'no-use-before-define': ['error', 'nofunc'],
     'no-var': 'error',
+    'prefer-const': 'error',
+    'prettier/prettier': [
+      'error',
+      {
+        singleQuote: true,
+        bracketSpacing: false,
+        trailingComma: 'es5',
+        arrowParens: 'avoid',
+      },
+    ],
     strict: 'off',
+    'sort-imports-es6-autofix/sort-imports-es6': [
+      'error',
+      {
+        ignoreCase: false,
+        ignoreMemberSort: false,
+        memberSyntaxSortOrder: ['none', 'all', 'single', 'multiple'],
+      },
+    ],
     'use-isnan': 'error',
     'valid-typeof': 'error',
-    'prefer-const': 'error',
   },
 };

--- a/index.js
+++ b/index.js
@@ -20,16 +20,6 @@ module.exports = {
     'import/default': 'error',
     'import/named': 'error',
     'import/no-unresolved': ['error', {commonjs: true}],
-    'import/order': [
-      'error',
-      {
-        groups: [
-          ['builtin', 'external'],
-          ['internal', 'parent', 'sibling', 'index'],
-        ],
-        'newlines-between': 'always',
-      },
-    ],
     'no-case-declarations': 'error',
     'no-cond-assign': 'error',
     'no-console': 'error',

--- a/package-lock.json
+++ b/package-lock.json
@@ -1163,13 +1163,6 @@
       "integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
       "requires": {
         "minimist": "^1.2.0"
-      },
-      "dependencies": {
-        "minimist": {
-          "version": "1.2.5",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-          "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
-        }
       }
     },
     "jsx-ast-utils": {
@@ -1851,19 +1844,12 @@
         "json5": "^1.0.1",
         "minimist": "^1.2.0",
         "strip-bom": "^3.0.0"
-      },
-      "dependencies": {
-        "minimist": {
-          "version": "1.2.5",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-          "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
-        }
       }
     },
     "tslib": {
-      "version": "1.13.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.13.0.tgz",
-      "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q=="
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
     },
     "type-check": {
       "version": "0.4.0",

--- a/react.js
+++ b/react.js
@@ -1,6 +1,6 @@
 module.exports = {
   extends: ['./index.js', 'prettier/react'],
-  plugins: ['react', 'sort-imports-es6-autofix', 'react-hooks'],
+  plugins: ['react', 'react-hooks'],
   parserOptions: {
     ecmaFeatures: {
       jsx: true,
@@ -32,13 +32,5 @@ module.exports = {
     'react/prop-types': 'error',
     'react/react-in-jsx-scope': 'error',
     'react/sort-prop-types': 'off',
-    'sort-imports-es6-autofix/sort-imports-es6': [
-      'error',
-      {
-        ignoreCase: false,
-        ignoreMemberSort: false,
-        memberSyntaxSortOrder: ['none', 'all', 'single', 'multiple'],
-      },
-    ],
   },
 };


### PR DESCRIPTION
I was wrong about the sorts import, we still need it. 👍 

- Moved import sorting and order to main ruleset
- Since we talk about sorting, I sorted the rules alphabetically (they were kinda but not fully)
- Converted es6 main.js to es6 and added local import
- Converted react function to variable holding arrow function

I did *not* change the version number, how do you feel about bumping it? Major, minor?
If you are fine with the PR feel free to bump it at your discretion, so we don't need another earth cycle 😄 