### PR TITLE
Introduce import order

### DIFF
--- a/examples/es6/main.js
+++ b/examples/es6/main.js
@@ -1,6 +1,7 @@
-import foo from './local-module';
 import fs from 'fs';
 import path from 'path';
+
+import foo from './local-module';
 
 const main = paths =>
   Promise.all(

--- a/index.js
+++ b/index.js
@@ -20,6 +20,16 @@ module.exports = {
     'import/default': 'error',
     'import/named': 'error',
     'import/no-unresolved': ['error', {commonjs: true}],
+    'import/order': [
+      'error',
+      {
+        groups: [
+          ['builtin', 'external'],
+          ['internal', 'parent', 'sibling', 'index'],
+        ],
+        'newlines-between': 'always',
+      },
+    ],
     'no-case-declarations': 'error',
     'no-cond-assign': 'error',
     'no-console': 'error',


### PR DESCRIPTION
Introduce import order to have local and external imports grouped together for better distinction, so they are not all mixed together.