### PR TITLE
Avoid duplicate and self imports

### DIFF
--- a/index.js
+++ b/index.js
@@ -19,6 +19,8 @@ module.exports = {
     eqeqeq: 'error',
     'import/default': 'error',
     'import/named': 'error',
+    'import/no-duplicates': 'error',
+    'import/no-self-import': 'error',
     'import/no-unresolved': ['error', {commonjs: true}],
     'no-case-declarations': 'error',
     'no-cond-assign': 'error',


### PR DESCRIPTION
WRONG

```js
import {foo} from 'fooPackage';
import {bar} from 'barPackage';
import {baz} from 'fooPackage';
```

RIGHT

```js
import {foo, baz} from 'fooPackage';
import {bar} from 'barPackage';
```

