### PR TITLE
Always have imports first

### DIFF
--- a/index.js
+++ b/index.js
@@ -18,6 +18,7 @@ module.exports = {
     'dot-notation': ['error', {allowPattern: '^[a-z]+(_[a-z]+)+$'}],
     eqeqeq: 'error',
     'import/default': 'error',
+    'import/first': 'error',
     'import/named': 'error',
     'import/no-duplicates': 'error',
     'import/no-self-import': 'error',


### PR DESCRIPTION
WRONG

```js
import foo from './foo';

// some module-level initializer
initWith(foo);

import bar from './bar';
```

RIGHT

```js
import foo from './foo';
import bar from './bar';

// some module-level initializer
initWith(foo);
```