### PR TITLE
Configure a list of files to be included in the package

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,2 +1,0 @@
-/examples/
-.travis.yml

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "20.0.0",
   "description": "ESLint config for Planet projects",
   "main": "index.js",
+  "files": ["index.js", "react.js"],
   "scripts": {
     "lint": "eslint . examples",
     "test": "npm run check-es6 && npm run check-react && npm run lint",


### PR DESCRIPTION
Having a list of allowed files is more straightforward to maintain than a list of excluded files (assuming many people publishing from different environments).  Too bad npm doesn't respect a global git excludes file (npm/npm#5673).

This is an alternative to and closes #43.

```
npm pack
```
```
npm notice 
npm notice 📦  eslint-config-planet@20.0.0
npm notice === Tarball Contents === 
npm notice 2.4kB index.js    
npm notice 1.1kB react.js    
npm notice 1.2kB package.json
npm notice 4.6kB readme.md   
npm notice === Tarball Details === 
npm notice name:          eslint-config-planet                    
npm notice version:       20.0.0                                  
npm notice filename:      eslint-config-planet-20.0.0.tgz         
npm notice package size:  3.4 kB                                  
npm notice unpacked size: 9.3 kB                                  
npm notice shasum:        fc3882f98044d0230940a2328ce71e9ae3306655
npm notice integrity:     sha512-CyqJ5bSDXgXlj[...]kUTQalp1SBSpw==
npm notice total files:   4                                       
npm notice 
eslint-config-planet-20.0.0.tgz
```