### PR TITLE
Add .jsx as default file extension to scan in addition to .js

### DIFF
--- a/react.js
+++ b/react.js
@@ -35,4 +35,9 @@ module.exports = {
     'react/react-in-jsx-scope': 'error',
     'react/sort-prop-types': 'off',
   },
+  overrides: [
+    {
+      files: ['*.js', '*.jsx'],
+    },
+  ],
 };


### PR DESCRIPTION
Adds ".jsx" as a file override for default scanning.