### PR TITLE
Require file extensions in import specifiers

### DIFF
--- a/examples/es6/main.js
+++ b/examples/es6/main.js
@@ -1,4 +1,4 @@
-import foo from './local-module';
+import foo from './local-module.js';
 import fs from 'fs';
 import path from 'path';
 

--- a/index.js
+++ b/index.js
@@ -17,6 +17,7 @@ module.exports = {
     'dot-notation': ['error', {allowPattern: '^[a-z]+(_[a-z]+)+$'}],
     eqeqeq: 'error',
     'import/default': 'error',
+    'import/extensions': ['error', 'always'],
     'import/first': 'error',
     'import/named': 'error',
     'import/no-duplicates': 'error',

--- a/react.js
+++ b/react.js
@@ -2,6 +2,8 @@ module.exports = {
   extends: ['./index.js'],
   plugins: ['react', 'react-hooks'],
   parserOptions: {
+    ecmaVersion: 'latest',
+    sourceType: 'module',
     ecmaFeatures: {
       jsx: true,
     },


### PR DESCRIPTION
This makes use of the [`import/extensions` rule](https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/extensions.md).