### PR TITLE
Ignore file extension on imports specifiers for packages

### DIFF
--- a/index.js
+++ b/index.js
@@ -17,7 +17,7 @@ module.exports = {
     'dot-notation': ['error', {allowPattern: '^[a-z]+(_[a-z]+)+$'}],
     eqeqeq: 'error',
     'import/default': 'error',
-    'import/extensions': ['error', 'always'],
+    'import/extensions': ['error', 'always', {ignorePackages: true}],
     'import/first': 'error',
     'import/named': 'error',
     'import/no-duplicates': 'error',


### PR DESCRIPTION
This makes it more likely that people will use this configuration.