### PR TITLE
Downgrade eslint-plugin-react-hooks

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "eslint-plugin-import": "^2.31.0",
         "eslint-plugin-prettier": "^5.2.1",
         "eslint-plugin-react": "^7.37.3",
-        "eslint-plugin-react-hooks": "^5.1.0",
+        "eslint-plugin-react-hooks": "5.0.0",
         "eslint-plugin-sort-imports-es6-autofix": "^0.6.0",
         "globals": "^15.14.0",
         "prettier": "^3.4.2"
@@ -1107,9 +1107,10 @@
       }
     },
     "node_modules/eslint-plugin-react-hooks": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-5.1.0.tgz",
-      "integrity": "sha512-mpJRtPgHN2tNAvZ35AMfqeB3Xqeo273QxrHJsbBEPWODRM4r0yB6jfoROqKEYrOn27UtRPpcpHc2UqyBSuUNTw==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-5.0.0.tgz",
+      "integrity": "sha512-hIOwI+5hYGpJEc4uPRmz2ulCjAGD/N13Lukkh8cLV0i2IRk/bdZDYjgLVHj+U9Z704kLIdIO6iueGvxNur0sgw==",
+      "license": "MIT",
       "engines": {
         "node": ">=10"
       },

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "eslint-plugin-import": "^2.31.0",
     "eslint-plugin-prettier": "^5.2.1",
     "eslint-plugin-react": "^7.37.3",
-    "eslint-plugin-react-hooks": "^5.1.0",
+    "eslint-plugin-react-hooks": "5.0.0",
     "eslint-plugin-sort-imports-es6-autofix": "^0.6.0",
     "globals": "^15.14.0",
     "prettier": "^3.4.2"


### PR DESCRIPTION
The latest release of eslint-plugin-react-hooks incorrectly flags uses of hooks as occurring in a loop if a component function body contains a loop.

Downgrading to version 5.0.0 is a workaround until the React team publishes a release with the fix in https://github.com/facebook/react/pull/28714 (merged but not yet released).

See https://github.com/facebook/react/issues/31687