### PR TITLE
Configure import sorting

### DIFF
--- a/examples/es6/main.js
+++ b/examples/es6/main.js
@@ -1,6 +1,6 @@
-import foo from './local-module.js';
 import fs from 'fs';
 import path from 'path';
+import foo from './local-module.js';
 
 const main = paths =>
   Promise.all(

--- a/examples/react/component.js
+++ b/examples/react/component.js
@@ -1,6 +1,6 @@
+import {string} from 'prop-types';
 import React, {useCallback, useState} from 'react';
 import ReactDOM from 'react-dom';
-import {string} from 'prop-types';
 
 const HelloMessage = ({name}) => {
   const [greeting, setGreeting] = useState('Hello');

--- a/index.js
+++ b/index.js
@@ -1,8 +1,7 @@
-import globals from 'globals';
-import importPlugin from 'eslint-plugin-import';
 import js from '@eslint/js';
+import importPlugin from 'eslint-plugin-import';
 import prettier from 'eslint-plugin-prettier';
-import sortImportPlugin from 'eslint-plugin-sort-imports-es6-autofix';
+import globals from 'globals';
 
 export default [
   js.configs.recommended,
@@ -11,7 +10,6 @@ export default [
     name: 'planet/recommended',
     plugins: {
       prettier,
-      'sort-imports-es6-autofix': sortImportPlugin,
     },
 
     languageOptions: {
@@ -25,41 +23,13 @@ export default [
     },
 
     rules: {
+      // core rules
       'array-callback-return': 'error',
       'block-scoped-var': 'error',
       curly: 'error',
       'default-case': 'error',
-
-      'dot-notation': [
-        'error',
-        {
-          allowPattern: '^[a-z]+(_[a-z]+)+$',
-        },
-      ],
-
+      'dot-notation': ['error', {allowPattern: '^[a-z]+(_[a-z]+)+$'}],
       eqeqeq: 'error',
-      'import/default': 'error',
-
-      'import/extensions': [
-        'error',
-        'always',
-        {
-          ignorePackages: true,
-        },
-      ],
-
-      'import/first': 'error',
-      'import/named': 'error',
-      'import/no-duplicates': 'error',
-      'import/no-self-import': 'error',
-
-      'import/no-unresolved': [
-        'error',
-        {
-          commonjs: true,
-        },
-      ],
-
       'no-case-declarations': 'error',
       'no-cond-assign': 'error',
       'no-console': 'error',
@@ -94,40 +64,29 @@ export default [
       'no-unexpected-multiline': 'error',
       'no-unreachable': 'error',
       'no-unsafe-finally': 'error',
-
-      'no-unused-vars': [
-        'error',
-        {
-          ignoreRestSiblings: true,
-        },
-      ],
-
+      'no-unused-vars': ['error', {ignoreRestSiblings: true}],
       'no-use-before-define': ['error', 'nofunc'],
       'no-var': 'error',
       'prefer-const': 'error',
-
-      'prettier/prettier': [
-        'error',
-        {
-          singleQuote: true,
-          bracketSpacing: false,
-          arrowParens: 'avoid',
-        },
-      ],
-
       strict: 'off',
-
-      'sort-imports-es6-autofix/sort-imports-es6': [
-        'error',
-        {
-          ignoreCase: false,
-          ignoreMemberSort: false,
-          memberSyntaxSortOrder: ['none', 'all', 'single', 'multiple'],
-        },
-      ],
-
       'use-isnan': 'error',
       'valid-typeof': 'error',
+
+      // import plugin
+      'import/default': 'error',
+      'import/extensions': ['error', 'always', {ignorePackages: true}],
+      'import/first': 'error',
+      'import/named': 'error',
+      'import/no-duplicates': 'error',
+      'import/no-self-import': 'error',
+      'import/no-unresolved': ['error', {commonjs: true}],
+      'import/order': ['error', {named: true, alphabetize: {order: 'asc'}}],
+
+      // prettier plugin
+      'prettier/prettier': [
+        'error',
+        {singleQuote: true, bracketSpacing: false, arrowParens: 'avoid'},
+      ],
     },
   },
 ];

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,6 @@
         "eslint-plugin-prettier": "^5.2.1",
         "eslint-plugin-react": "^7.37.3",
         "eslint-plugin-react-hooks": "5.0.0",
-        "eslint-plugin-sort-imports-es6-autofix": "^0.6.0",
         "globals": "^15.14.0",
         "prettier": "^3.4.2"
       },
@@ -90,12 +89,6 @@
         }
       }
     },
-    "node_modules/@eslint/config-array/node_modules/ms": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "license": "MIT"
-    },
     "node_modules/@eslint/core": {
       "version": "0.9.1",
       "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.9.1.tgz",
@@ -159,12 +152,6 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
-    },
-    "node_modules/@eslint/eslintrc/node_modules/ms": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "license": "MIT"
     },
     "node_modules/@eslint/js": {
       "version": "9.17.0",
@@ -1134,15 +1121,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/eslint-plugin-sort-imports-es6-autofix": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-sort-imports-es6-autofix/-/eslint-plugin-sort-imports-es6-autofix-0.6.0.tgz",
-      "integrity": "sha512-2NVaBGF9NN+727Fyq+jJYihdIeegjXeUUrZED9Q8FVB8MsV3YQEyXG96GVnXqWt0pmn7xfCZOZf3uKnIhBrfeQ==",
-      "license": "MIT",
-      "peerDependencies": {
-        "eslint": ">=7.7.0"
-      }
-    },
     "node_modules/eslint-scope": {
       "version": "8.2.0",
       "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-8.2.0.tgz",
@@ -1171,11 +1149,12 @@
       }
     },
     "node_modules/eslint/node_modules/debug": {
-      "version": "4.3.4",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.0.tgz",
+      "integrity": "sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA==",
+      "license": "MIT",
       "dependencies": {
-        "ms": "2.1.2"
+        "ms": "^2.1.3"
       },
       "engines": {
         "node": ">=6.0"
@@ -1704,9 +1683,10 @@
       }
     },
     "node_modules/is-core-module": {
-      "version": "2.15.1",
-      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.15.1.tgz",
-      "integrity": "sha512-z0vtXSwucUJtANQWldhbtbt7BnL0vxiFjIdDLAatwhDYty2bad6s+rijD6Ri4YuYJubLzIJLUidCh09e1djEVQ==",
+      "version": "2.16.1",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.1.tgz",
+      "integrity": "sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==",
+      "license": "MIT",
       "dependencies": {
         "hasown": "^2.0.2"
       },
@@ -2096,9 +2076,10 @@
       }
     },
     "node_modules/ms": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
     },
     "node_modules/natural-compare": {
       "version": "1.4.0",
@@ -2393,16 +2374,20 @@
       }
     },
     "node_modules/resolve": {
-      "version": "1.22.8",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.8.tgz",
-      "integrity": "sha512-oKWePCxqpd6FlLvGV1VU0x7bkPmmCNolxzjMf4NczoDnQcIWrAF+cPtZn5i6n+RfD2d9i0tzpKnG6Yk168yIyw==",
+      "version": "1.22.10",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.10.tgz",
+      "integrity": "sha512-NPRy+/ncIMeDlTAsuqwKIiferiawhefFJtkNSW0qZJEqMEb+qBt/77B/jGeeek+F0uOeN05CDa6HXbbIgtVX4w==",
+      "license": "MIT",
       "dependencies": {
-        "is-core-module": "^2.13.0",
+        "is-core-module": "^2.16.0",
         "path-parse": "^1.0.7",
         "supports-preserve-symlinks-flag": "^1.0.0"
       },
       "bin": {
         "resolve": "bin/resolve"
+      },
+      "engines": {
+        "node": ">= 0.4"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"

--- a/package.json
+++ b/package.json
@@ -32,7 +32,6 @@
     "eslint-plugin-prettier": "^5.2.1",
     "eslint-plugin-react": "^7.37.3",
     "eslint-plugin-react-hooks": "5.0.0",
-    "eslint-plugin-sort-imports-es6-autofix": "^0.6.0",
     "globals": "^15.14.0",
     "prettier": "^3.4.2"
   }

--- a/react.js
+++ b/react.js
@@ -1,6 +1,6 @@
-import planetConfig from './index.js';
 import react from 'eslint-plugin-react';
 import reactHooks from 'eslint-plugin-react-hooks';
+import planetConfig from './index.js';
 
 export default [
   ...planetConfig,


### PR DESCRIPTION
This replaces use of the [`eslint-plugin-sort-imports-es6-autofix` package](https://www.npmjs.com/package/eslint-plugin-sort-imports-es6-autofix) with the [`import/order` rule](https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/order.md) from the [`eslint-plugin-import` package](https://www.npmjs.com/package/eslint-plugin-import).

As can be seen in the diff, the import order enforced between the two packages is not the same. But the `eslint-plugin-import` package works with ESLint 9 and the `eslint-plugin-sort-imports-es6-autofix` is not actively maintained.